### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
     - git clone https://github.com/hpicgs/glbinding.git
     - pushd glbinding
     - git checkout v1.0.3
-    - cmake -DBUILD_SHARED_LIBS=ON . && make && sudo make install
+    - cmake -DOPTION_BUILD_STATIC=OFF . && make && sudo make install
     - popd
 before_script:
     - mkdir build && pushd build


### PR DESCRIPTION
You should use the dedicated option of our CMakeLists.txt as the `BUILD_SHARED_LIBS` variable will get overwritten within the first lines (see https://github.com/hpicgs/glbinding/blob/master/CMakeLists.txt#L39). Either way, building glbinding as shared library is the default setting.
